### PR TITLE
Extract org name and repo name from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ by adding `gitea` to the list of dependencies in your `mix.exs` file:
 ```elixir
 def deps do
   [
-    {:gitea, "~> 0.1.0"}
+    {:gitea, "~> 1.0.1"}
   ]
 end
 ```

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -58,14 +58,34 @@ defmodule Gitea.Helpers do
     remote_url(git_url, org, repo)
   end
 
+  @doc """
+  returns {org, repo} from git url
+  ## Examples
+    iex> Gitea.Helpers.get_org_repo_names("git@gitea-server.fly.dev:myorg/myrepo.git")
+    {"myorg", "myrepo"}
+
+    iex> Gitea.Helpers.get_org_repo_names("ssh://git@gitea-server.fly.dev:10022/theorg/myrepo.git")
+    {"theorg", "myrepo"}
+
+    iex> Gitea.Helpers.get_org_repo_names("https://gitea-server.fly.dev/myorg/public-repo.git")
+    {"myorg", "public-repo"}
+  """
   @spec get_org_repo_names(String.t()) :: {String.t(), String.t()}
-  defp get_org_repo_names(url) do
-    [org, repo] =
+  def get_org_repo_names(url) do
+    if String.starts_with?(url, "git") do
       url
+      |> String.split(":")
+      |> List.last()
+      |> Path.rootname()
+      |> Path.split()
+      |> List.to_tuple()
+    else
+      url
+      |> Path.rootname()
       |> String.split("/")
       |> Enum.take(-2)
-
-    {org, repo}
+      |> List.to_tuple()
+    end
   end
 
   @doc """
@@ -75,7 +95,7 @@ defmodule Gitea.Helpers do
   @spec get_repo_name_from_url(String.t()) :: String.t()
   def get_repo_name_from_url(url) do
     {_org, repo} = get_org_repo_names(url)
-    String.split(repo, ".git") |> List.first()
+    repo
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Gitea.MixProject do
   def project do
     [
       app: :gitea,
-      version: "0.1.0",
+      version: "1.0.1",
       elixir: @elixir_requirement,
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/httpoison_mock_test.exs
+++ b/test/httpoison_mock_test.exs
@@ -25,6 +25,11 @@ defmodule HttPoisonMockTest do
     assert body_map.full_name == "myorg/simon"
   end
 
+  test "Gitea.HTTPoisonMock.delete /orgs should return 204 " do
+    {:ok, %HTTPoison.Response{status_code: status}} = Gitea.HTTPoisonMock.delete("/orgs")
+    assert status == 204
+  end
+
   test "Gitea.HTTPoisonMock.delete any url should return status 200" do
     {:ok, %HTTPoison.Response{status_code: status}} = Gitea.HTTPoisonMock.delete("any?url")
     assert status == 200


### PR DESCRIPTION
Update function to extract org and repo name from different
type of url, ssh, git, https

ref: #12