### PR TITLE
Add auto_init value in create repo body request

### DIFF
--- a/lib/gitea.ex
+++ b/lib/gitea.ex
@@ -38,6 +38,7 @@ defmodule Gitea do
     Logger.info("remote_repo_create api endpoint: #{url}")
 
     params = %{
+      auto_init: true,
       name: repo_name,
       private: private,
       description: repo_name,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Gitea.MixProject do
   def project do
     [
       app: :gitea,
-      version: "1.0.3",
+      version: "1.0.4",
       elixir: @elixir_requirement,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Add auto_init to automatically create the initialisation of the repository.
This will create the README.md file when the repository is created

see: #18

This is also linked to #19 but we can improve on the body options later on.